### PR TITLE
WIP: Added a lifecycle flag and argument to the ChangeNetwork Transform.

### DIFF
--- a/change_network.go
+++ b/change_network.go
@@ -14,17 +14,40 @@ import (
 // an instance group is placed in.
 type NetworkMover struct {
 	InstanceGroup string
+	Lifecycle     string
 	Network       string
 	StaticIPs     []string
 	ipsFlag       string
 }
 
 func (n *NetworkMover) Apply(dm *enaml.DeploymentManifest) error {
-	ig := dm.GetInstanceGroupByName(n.InstanceGroup)
-	if ig == nil {
-		return fmt.Errorf("couldn't find instance group %s", n.InstanceGroup)
+
+	if n.InstanceGroup != "" {
+		ig := dm.GetInstanceGroupByName(n.InstanceGroup)
+		if ig == nil {
+			return fmt.Errorf("couldn't find instance group %s", n.InstanceGroup)
+		}
+		return n.applyToInstanceGroup(ig)
 	}
 
+	if n.Lifecycle != "" {
+		var err error
+		for _, ig := range dm.InstanceGroups {
+			if ig.Lifecycle == n.Lifecycle {
+				err = n.applyToInstanceGroup(ig)
+				if err != nil {
+					return fmt.Errorf("error applying transformation to instance group %s: %v\n", ig.Name, err)
+				}
+			}
+		}
+		return nil
+	}
+
+	return errors.New("transform was not applied by instance group or lifecycle")
+
+}
+
+func (n *NetworkMover) applyToInstanceGroup(ig *enaml.InstanceGroup) error {
 	if l := len(ig.Networks); l != 1 {
 		return fmt.Errorf("expected 1 network, found %d", l)
 	}
@@ -34,13 +57,13 @@ func (n *NetworkMover) Apply(dm *enaml.DeploymentManifest) error {
 	if len(n.StaticIPs) > 0 {
 		ig.Networks[0].StaticIPs = n.StaticIPs
 	}
-
 	return nil
 }
 
 func (n *NetworkMover) flagSet() *flag.FlagSet {
-	fs := flag.NewFlagSet("change-network", flag.ExitOnError)
-	fs.StringVar(&n.InstanceGroup, "instance-group", "", "name of the instance group")
+	fs := flag.NewFlagSet("change-network", flag.ContinueOnError)
+	fs.StringVar(&n.InstanceGroup, "instance-group", "", "apply transformation to the instance group with this name")
+	fs.StringVar(&n.Lifecycle, "lifecycle", "", "apply transformation to all instance groups with this lifecycle")
 	fs.StringVar(&n.Network, "network", "", "the name of the network to use")
 	fs.StringVar(&n.ipsFlag, "static-ips", "", "comma-separated list of static IP ranges to set on the network")
 	return fs
@@ -56,11 +79,14 @@ func ChangeNetworkTransformation(args []string) (Transformation, error) {
 		return nil, err
 	}
 
-	if n.InstanceGroup == "" {
-		return nil, errors.New("missing required flag -instance-group")
+	igPresent := n.InstanceGroup == ""
+	lifecyclePresent := n.Lifecycle == ""
+
+	if igPresent == lifecyclePresent {
+		return nil, errors.New("either -lifecycle or -instance-group must be specified, but not both")
 	}
 	if n.Network == "" {
-		return nil, errors.New("missing required flag network")
+		return nil, errors.New("missing required flag -network")
 	}
 	if n.ipsFlag != "" {
 		n.StaticIPs = split(n.ipsFlag, ",")


### PR DESCRIPTION
The -lifecycle flag can now be used instead of the -instance-group flag in order to apply the ChangeNetwork Transform to all instance groups of the specified lifecycle. Only -lifecycle or -instance-group will be accepted, not both.

- [x] Update ChangeNetwork Transform
- [ ] Update ChangeAZ Transform